### PR TITLE
Agregar servicios base frontend, backend y attacker

### DIFF
--- a/services/attacker/scanner.py
+++ b/services/attacker/scanner.py
@@ -1,0 +1,98 @@
+import json
+import socket
+import sys
+from datetime import datetime
+
+
+def scan_target(host, port, timeout=2):
+    try:
+        # Crear socket TCP
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+
+        # Intentar conectar
+        result = sock.connect_ex((host, port))
+        sock.close()
+
+        # Si result es 0, la conexión fue exitosa
+        if result == 0:
+            return "OPEN"
+        else:
+            return "CLOSED"
+
+    except socket.gaierror:
+        # Error de resolución DNS
+        return "ERROR-DNS"
+    except socket.timeout:
+        # Timeout de conexión
+        return "CLOSED"
+    except Exception:
+        # Cualquier otro error
+        return "ERROR"
+
+
+def main():
+    # Lista de targets a escanear (host, puerto, descripción)
+    targets = [
+        ("frontend", 80, "Frontend HTTP"),
+        ("frontend", 8080, "Frontend Flask"),
+        ("backend", 5000, "Backend API"),
+        ("backend", 5432, "Backend DB (simulado)"),
+    ]
+
+    print("Iniciando escaneo de red...", file=sys.stderr)
+    print(f"Fecha: {datetime.now().isoformat()}", file=sys.stderr)
+    print(f"Targets: {len(targets)}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    results = []
+
+    for host, port, description in targets:
+        target_str = f"{host}:{port}"
+        print(f"Escaneando {target_str} ({description})...", file=sys.stderr)
+
+        status = scan_target(host, port)
+
+        result = {
+            "target": target_str,
+            "host": host,
+            "port": port,
+            "description": description,
+            "status": status,
+        }
+
+        results.append(result)
+
+        # Mostrar resultado en stderr (no interferir con JSON en stdout)
+        status_symbol = "✓" if status == "OPEN" else "✗"
+        print(f"  {status_symbol} {target_str}: {status}", file=sys.stderr)
+
+    print("", file=sys.stderr)
+    print("Escaneo completado", file=sys.stderr)
+
+    # Generar reporte JSON
+    report = {
+        "scan_date": datetime.now().isoformat(),
+        "scanner": "attacker",
+        "environment": "docker-compose",
+        "total_targets": len(targets),
+        "results": results,
+    }
+
+    # Calcular estadísticas
+    open_count = sum(1 for r in results if r["status"] == "OPEN")
+    closed_count = sum(1 for r in results if r["status"] == "CLOSED")
+    error_count = sum(1 for r in results if "ERROR" in r["status"])
+
+    report["summary"] = {
+        "open": open_count,
+        "closed": closed_count,
+        "errors": error_count,
+    }
+
+    # Imprimir JSON a stdout (esto es lo que se captura en el reporte)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/backend/app.py
+++ b/services/backend/app.py
@@ -1,0 +1,41 @@
+import socket
+
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def home():
+    """Endpoint raíz - verificación de que el servicio funciona"""
+    return jsonify(
+        {
+            "service": "backend",
+            "status": "OK",
+            "message": "Backend service is running",
+            "hostname": socket.gethostname(),
+        }
+    )
+
+
+@app.route("/health")
+def health():
+    """Endpoint de health check"""
+    return jsonify({"status": "healthy", "service": "backend"}), 200
+
+
+@app.route("/api/data")
+def get_data():
+    """Endpoint simulado con datos sensibles"""
+    return jsonify(
+        {
+            "data": "sensitive information",
+            "message": "This endpoint should be protected",
+        }
+    )
+
+
+if __name__ == "__main__":
+    # Escuchar en todas las interfaces (0.0.0.0)
+    # Puerto 5000
+    app.run(host="0.0.0.0", port=5000, debug=False)

--- a/services/backend/requirements.txt
+++ b/services/backend/requirements.txt
@@ -1,0 +1,5 @@
+# services/frontend/requirements.txt
+# Dependencias del backend
+
+Flask==3.0.0
+Werkzeug==3.0.1

--- a/services/frontend/app.py
+++ b/services/frontend/app.py
@@ -1,0 +1,30 @@
+import socket
+
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def home():
+    """Endpoint raíz - verificación de que el servicio funciona"""
+    return jsonify(
+        {
+            "service": "frontend",
+            "status": "OK",
+            "message": "Frontend service is running",
+            "hostname": socket.gethostname(),
+        }
+    )
+
+
+@app.route("/health")
+def health():
+    """Endpoint de health check"""
+    return jsonify({"status": "healthy", "service": "frontend"}), 200
+
+
+if __name__ == "__main__":
+    # Escuchar en todas las interfaces (0.0.0.0) para que Docker pueda acceder
+    # Puerto 8080
+    app.run(host="0.0.0.0", port=8080, debug=False)

--- a/services/frontend/requirements.txt
+++ b/services/frontend/requirements.txt
@@ -1,0 +1,5 @@
+# services/frontend/requirements.txt
+# Dependencias del frontend
+
+Flask==3.0.0
+Werkzeug==3.0.1


### PR DESCRIPTION
## Descripción
Se implementan los servicios iniciales del proyecto requeridos en el Sprint 1.  
Cada servicio incluye una aplicación Python mínima y su archivo `requirements.txt`.

---

## Cambios incluidos
- `services/frontend/app.py`
- `services/frontend/requirements.txt`
- `services/backend/app.py`
- `services/backend/requirements.txt`
- `services/attacker/scanner.py`

---

## Issue relacionado
Closes #2 — Servicios Python básicos

---

## Checklist
- [x] Servicios responden correctamente en ejecución local  
- [x] Estructura compatible con los siguientes pasos del Sprint 1 